### PR TITLE
添加选择性媒体缓存和 sessionStorage 以提升性能

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -9,6 +9,7 @@ import {
   getCoverAspectRatio,
   getNormalizedCoverAspectRatio,
 } from "~/utils/cover";
+import { readHomeFeedSnapshot, writeHomeFeedSnapshot } from "~/utils/home-feed-cache";
 import { calculateSkeletonCount, estimateSkeletonHeight, generateSkeletons, type SkeletonItem } from "~/utils/skeleton";
 import { ArrowPathIcon } from "@heroicons/vue/24/outline";
 
@@ -134,18 +135,31 @@ const toUniqueNodes = (nodes: Discussion[], reset: boolean): Discussion[] => {
   return unique;
 };
 
-const scrollToTopAfterReset = async (reset: boolean) => {
+const scrollToTopAfterReset = async (reset: boolean, skipScroll = false) => {
   await nextTick();
-  if (reset && import.meta.client) {
+  if (reset && import.meta.client && !skipScroll) {
     window.scrollTo({ top: 0, behavior: "auto" });
   }
 };
 
-const fetchList = async (reset = false) => {
+/** Restore list from sessionStorage for this search query; returns true if a snapshot was applied (including empty list). */
+const tryHydrateFromCache = (q: string): boolean => {
+  if (!import.meta.client) return false;
+  const snap = readHomeFeedSnapshot(q);
+  if (snap === null) return false;
+  list.value = snap.nodes;
+  endCursor.value = snap.endCursor;
+  hasNextPage.value = snap.hasNextPage;
+  seenIds = new Set(snap.nodes.map((d) => d.id).filter(Boolean));
+  return true;
+};
+
+const fetchList = async (reset = false, opts?: { silent?: boolean }) => {
   if (loading.value || loadingMore.value) return;
   if (!hasNextPage.value && !reset) return;
 
-  const shouldShowPageProgress = reset && !refreshing.value;
+  const silent = Boolean(opts?.silent && reset);
+  const shouldShowPageProgress = reset && !refreshing.value && !silent;
   if (shouldShowPageProgress) {
     if (!pageDataLoading.isActive.value) {
       pageDataLoading.start();
@@ -153,11 +167,14 @@ const fetchList = async (reset = false) => {
     pageDataLoading.claim();
   }
 
-  if (reset && !refreshing.value) {
+  if (reset && !refreshing.value && !silent) {
     loading.value = true;
   } else if (!reset) {
     loadingMore.value = true;
   }
+
+  const previousIds =
+    reset && silent && import.meta.client ? new Set(list.value.map((d) => d.id)) : null;
 
   const currentVersion = ++requestVersion.value;
   try {
@@ -169,8 +186,15 @@ const fetchList = async (reset = false) => {
     const uniqueNodes = toUniqueNodes(page.nodes, reset);
 
     if (reset) {
-      enterAnimationIds.value = new Set();
-      list.value = uniqueNodes;
+      if (silent && previousIds && previousIds.size > 0) {
+        const newOnes = uniqueNodes.filter((n) => n.id && !previousIds.has(n.id));
+        enterAnimationIds.value = new Set();
+        if (newOnes.length) addEnterAnimations(newOnes);
+        list.value = uniqueNodes;
+      } else {
+        enterAnimationIds.value = new Set();
+        list.value = uniqueNodes;
+      }
     } else {
       addEnterAnimations(uniqueNodes);
       list.value = [...list.value, ...uniqueNodes];
@@ -179,7 +203,16 @@ const fetchList = async (reset = false) => {
     endCursor.value = page.endCursor;
     hasNextPage.value = page.hasNextPage;
 
-    await scrollToTopAfterReset(reset);
+    await scrollToTopAfterReset(reset, silent);
+
+    if (import.meta.client) {
+      writeHomeFeedSnapshot({
+        query: query.value.trim(),
+        nodes: list.value,
+        endCursor: endCursor.value,
+        hasNextPage: hasNextPage.value,
+      });
+    }
   } catch (err) {
     message.error(resolveErrorMessage(err, "获取帖子失败"));
   } finally {
@@ -205,6 +238,12 @@ const goDiscussion = (discussion: Discussion, event: MouseEvent) => {
       d.id === discussion.id ? { ...d, isRead: true } : d,
     );
     list.value = next;
+    writeHomeFeedSnapshot({
+      query: query.value.trim(),
+      nodes: list.value,
+      endCursor: endCursor.value,
+      hasNextPage: hasNextPage.value,
+    });
   }
   api.markAsReadBatch([discussion.id]).catch(() => {});
 };
@@ -268,7 +307,12 @@ const observeLoadMoreSentinel = () => {
   loadMoreObserverRef.value = observer;
 };
 
-const debouncedSearch = useDebounceFn(() => fetchList(true), 300);
+const debouncedSearch = useDebounceFn(() => {
+  if (!import.meta.client) return;
+  const q = query.value.trim();
+  const had = tryHydrateFromCache(q);
+  void fetchList(true, { silent: had });
+}, 300);
 
 watch(
   () => query.value,
@@ -295,8 +339,9 @@ watch(
   { flush: "post" },
 );
 
-// 在 setup 阶段提前发起首屏数据请求，不等 onMounted
-const initialFetchPromise = fetchList(true);
+// 在 setup 阶段：有同关键词快照则先展示，再静默拉取；否则骨架 + 网络首屏
+const initialHadCache = import.meta.client ? tryHydrateFromCache(query.value.trim()) : false;
+const initialFetchPromise = fetchList(true, { silent: initialHadCache });
 
 // Triggered by MobileBottomNav when the user double-taps the active
 // "推送" entry — mirrors the Flutter app's pull-to-refresh shortcut.

--- a/app/pages/profile/[id].vue
+++ b/app/pages/profile/[id].vue
@@ -3,6 +3,7 @@ import { useMessage } from "zenless-ui";
 import type { Avatar, BusinessCard, Discussion, Profile } from "~/types/entities";
 import { resolveErrorMessage } from "~/utils/api-error";
 import { getCoverAspectRatio } from "~/utils/cover";
+import { readProfilePageSnapshot, writeProfilePageSnapshot } from "~/utils/profile-page-cache";
 
 const route = useRoute();
 const router = useRouter();
@@ -14,6 +15,7 @@ const message = useMessage();
 const profile = ref<Profile | null>(null);
 const loadError = ref(false);
 const loading = ref(false);
+const profileTabLabel = useState<string | null>("profileTabLabel", () => null);
 
 const SETTINGS_MODALS = ['settings', 'edit-name', 'edit-bio', 'pinned', 'social', 'logout'];
 const modalQuery = computed(() => String(route.query.modal || ''));
@@ -38,18 +40,166 @@ const profileId = computed(() => String(route.params.id || ""));
 
 const PROFILE_ARTICLES_MAX = 6;
 
-const loadProfileArticles = async () => {
-  if (articleLoading.value || !articleHasNext.value) return;
+/** Bumped on each full profile page load; stale responses must not write UI or storage. */
+const profilePageLoadSeq = ref(0);
+
+const persistProfileSnapshot = (roundSeq?: number) => {
+  if (roundSeq !== undefined && roundSeq !== profilePageLoadSeq.value) return;
+  if (!import.meta.client || !profile.value) return;
+  if (profile.value.documentId !== profileId.value) return;
+  writeProfilePageSnapshot({
+    profileId: profileId.value,
+    profile: profile.value,
+    articles: articles.value,
+    articleCursor: articleCursor.value,
+    articleHasNext: articleHasNext.value,
+  });
+};
+
+/** Restore profile + article grid from sessionStorage; returns true if a snapshot was applied (including empty articles). */
+const tryHydrateFromCache = (id: string): boolean => {
+  if (!import.meta.client || !id) return false;
+  const snap = readProfilePageSnapshot(id);
+  if (snap === null) return false;
+  profile.value = snap.profile;
+  articles.value = [...snap.articles];
+  articleCursor.value = snap.articleCursor;
+  articleHasNext.value = snap.articleHasNext;
+  profileTabLabel.value = snap.profile.isSelf
+    ? null
+    : (snap.profile.name || snap.profile.login || null);
+  loadError.value = false;
+  return true;
+};
+
+/**
+ * One page of profile articles for a fixed `pid` (not live route).
+ * Returns true if a response was applied; false if stale/skipped (no ref changes).
+ * For `replace`, always requests the first page (start "") so silent refresh need not mutate cursor before fetch.
+ */
+const loadProfileArticlesGridOnce = async (
+  pid: string,
+  roundSeq: number,
+  opts?: { replace?: boolean },
+): Promise<boolean> => {
+  const replace = opts?.replace === true;
+  if (roundSeq !== profilePageLoadSeq.value) return false;
+  if (!pid) return false;
+  if (!replace && !articleHasNext.value) return false;
+  const fetchCursor = replace ? "" : articleCursor.value;
+  // Do not gate on articleLoading: an older round may still hold true until its request ends;
+  // stale completions clear loading only when roundSeq still matches (see finally).
   articleLoading.value = true;
   try {
-    const page = await api.getProfileArticles(profileId.value, articleCursor.value, PROFILE_ARTICLES_MAX);
-    articles.value.push(...page.nodes);
+    const page = await api.getProfileArticles(pid, fetchCursor, PROFILE_ARTICLES_MAX);
+    if (roundSeq !== profilePageLoadSeq.value) return false;
+    if (replace) {
+      articles.value = [...page.nodes];
+    } else {
+      articles.value.push(...page.nodes);
+    }
     articleCursor.value = page.endCursor;
-    articleHasNext.value = false;
+    articleHasNext.value = page.hasNextPage;
+    return true;
   } catch (err) {
-    message.error(resolveErrorMessage(err, "获取用户帖子失败"));
+    if (roundSeq === profilePageLoadSeq.value) {
+      message.error(resolveErrorMessage(err, "获取用户帖子失败"));
+    }
+    throw err;
   } finally {
-    articleLoading.value = false;
+    if (roundSeq === profilePageLoadSeq.value) {
+      articleLoading.value = false;
+    }
+  }
+};
+
+const loadProfilePage = async (opts?: { silent?: boolean }) => {
+  const silent = opts?.silent === true;
+  const pid = profileId.value;
+  if (!pid) return;
+
+  const seq = ++profilePageLoadSeq.value;
+  const isStale = () => seq !== profilePageLoadSeq.value;
+  // Drop stale article in-flight lock so this round can always start grid fetch after getProfile.
+  articleLoading.value = false;
+
+  if (!silent) {
+    loading.value = true;
+    loadError.value = false;
+    pageDataLoading.claim();
+  } else {
+    loading.value = false;
+  }
+  try {
+    const p = await api.getProfile(pid);
+    if (isStale()) return;
+
+    let persistOk = true;
+
+    if (silent) {
+      if (p.isHidden) {
+        profile.value = p;
+        profileTabLabel.value = p.isSelf ? null : (p.name || p.login || null);
+        articles.value = [];
+        articleCursor.value = "";
+        articleHasNext.value = false;
+      } else {
+        articleLoading.value = true;
+        try {
+          const page = await api.getProfileArticles(pid, "", PROFILE_ARTICLES_MAX);
+          if (isStale()) return;
+          profile.value = p;
+          profileTabLabel.value = p.isSelf ? null : (p.name || p.login || null);
+          articles.value = [...page.nodes];
+          articleCursor.value = page.endCursor;
+          articleHasNext.value = page.hasNextPage;
+        } catch (err) {
+          if (!isStale()) {
+            message.error(resolveErrorMessage(err, "获取用户帖子失败"));
+          }
+          persistOk = false;
+        } finally {
+          if (seq === profilePageLoadSeq.value) {
+            articleLoading.value = false;
+          }
+        }
+      }
+    } else {
+      profile.value = p;
+      profileTabLabel.value = p.isSelf ? null : (p.name || p.login || null);
+
+      if (p.isHidden) {
+        articles.value = [];
+        articleCursor.value = "";
+        articleHasNext.value = false;
+      } else {
+        articleCursor.value = "";
+        articleHasNext.value = true;
+        articles.value = [];
+        try {
+          persistOk = await loadProfileArticlesGridOnce(pid, seq, { replace: true });
+        } catch {
+          if (isStale()) return;
+          persistOk = false;
+        }
+      }
+    }
+
+    if (isStale() || profileId.value !== pid) return;
+    if (persistOk) {
+      persistProfileSnapshot(seq);
+    }
+  } catch (err) {
+    if (isStale()) return;
+    if (!silent) {
+      loadError.value = true;
+    }
+    message.error(resolveErrorMessage(err, "获取用户信息失败"));
+  } finally {
+    if (!silent && seq === profilePageLoadSeq.value) {
+      loading.value = false;
+      pageDataLoading.finish();
+    }
   }
 };
 
@@ -71,6 +221,7 @@ const authStore = useAuthStore();
 const onCardEquipped = (card: BusinessCard | null) => {
   if (profile.value) {
     profile.value = { ...profile.value, equippedCard: card ?? undefined };
+    persistProfileSnapshot();
   }
 };
 
@@ -81,6 +232,7 @@ const onAvatarEquipped = (avatar: Avatar | null) => {
       equippedAvatar: avatar ?? undefined,
       avatar: avatar?.image || profile.value.avatar,
     };
+    persistProfileSnapshot();
   }
   authStore.fetchSelfUser();
 };
@@ -92,6 +244,7 @@ const onCustomAvatarUploaded = (avatarUrl: string) => {
       equippedAvatar: undefined,
       avatar: avatarUrl,
     };
+    persistProfileSnapshot();
   }
   authStore.fetchSelfUser();
 };
@@ -99,6 +252,7 @@ const onCustomAvatarUploaded = (avatarUrl: string) => {
 const onNameUpdated = (name: string) => {
   if (profile.value) {
     profile.value = { ...profile.value, name };
+    persistProfileSnapshot();
   }
   authStore.fetchSelfUser();
 };
@@ -106,22 +260,42 @@ const onNameUpdated = (name: string) => {
 const onBioUpdated = (bio: string) => {
   if (profile.value) {
     profile.value = { ...profile.value, bio: bio || undefined };
+    persistProfileSnapshot();
   }
 };
 
 const onHiddenUpdated = (h: boolean) => {
   if (profile.value) {
     profile.value = { ...profile.value, profileHidden: h };
+    persistProfileSnapshot();
   }
 };
 
 const onPinnedUpdated = async (_pinned: string[] | null) => {
+  const pid = profileId.value;
+  if (!pid) return;
+  // 新轮次：取消进行中的整页/文章请求，避免与 loadProfilePage 内的 grid 请求互锁（articleLoading）
+  const seq = ++profilePageLoadSeq.value;
+  articleLoading.value = false;
+  loading.value = false;
+  pageDataLoading.finish();
   // 重置文章列表并重新加载，以应用新的精选配置
   articles.value = [];
   articleCursor.value = "";
   articleHasNext.value = true;
+  let persistOk = true;
   if (!profile.value?.isHidden) {
-    await loadProfileArticles();
+    try {
+      persistOk = await loadProfileArticlesGridOnce(pid, seq, { replace: true });
+    } catch {
+      persistOk = false;
+    }
+  } else {
+    articleHasNext.value = false;
+  }
+  if (seq !== profilePageLoadSeq.value || profileId.value !== pid) return;
+  if (persistOk) {
+    persistProfileSnapshot(seq);
   }
 };
 
@@ -150,8 +324,6 @@ useSeoMeta({
   ogDescription: profileDescription,
   ogImage: () => profile.value?.avatar || "/images/zzzicon_200x200.png",
 });
-
-const profileTabLabel = useState<string | null>("profileTabLabel", () => null);
 
 // Lock page scroll only on large landscape viewports where the layout is
 // designed to fit in a single screen. On medium/portrait/mobile viewports
@@ -185,25 +357,25 @@ onMounted(async () => {
     applyScrollLock(_scrollLockMql.matches);
   }
 
-  loading.value = true;
-  loadError.value = false;
-  pageDataLoading.claim();
-  try {
-    profile.value = await api.getProfile(profileId.value);
-    profileTabLabel.value = profile.value?.isSelf
-      ? null
-      : (profile.value?.name || profile.value?.login || null);
-  } catch (err) {
-    loadError.value = true;
-    message.error(resolveErrorMessage(err, "获取用户信息失败"));
-  } finally {
-    loading.value = false;
-    pageDataLoading.finish();
-  }
-  if (profile.value && !profile.value.isHidden) {
-    void loadProfileArticles();
-  }
+  const hadCache = import.meta.client ? tryHydrateFromCache(profileId.value) : false;
+  await loadProfilePage({ silent: hadCache });
 });
+
+watch(
+  () => profileId.value,
+  async (id, prevId) => {
+    if (!import.meta.client || !id || id === prevId) return;
+    profileTabLabel.value = null;
+    const had = tryHydrateFromCache(id);
+    if (!had) {
+      profile.value = null;
+      articles.value = [];
+      articleCursor.value = "";
+      articleHasNext.value = true;
+    }
+    await loadProfilePage({ silent: had });
+  },
+);
 
 onBeforeUnmount(() => {
   profileTabLabel.value = null;

--- a/app/plugins/sw-register.client.ts
+++ b/app/plugins/sw-register.client.ts
@@ -1,0 +1,12 @@
+export default defineNuxtPlugin(() => {
+  if (!import.meta.client || !("serviceWorker" in navigator)) return;
+
+  const config = useRuntimeConfig();
+  const enabled = import.meta.env.PRODUCTION === true || config.public.enableServiceWorker === true;
+
+  if (!enabled) return;
+
+  navigator.serviceWorker.register("/sw.js").catch(() => {
+    // Registration can fail on unsupported hosts or during transient errors
+  });
+});

--- a/app/utils/home-feed-cache.ts
+++ b/app/utils/home-feed-cache.ts
@@ -1,0 +1,66 @@
+import type { Discussion } from "~/types/entities";
+
+const STORAGE_PREFIX = "ik-home-feed:v1:";
+
+export interface HomeFeedSnapshot {
+  version: 1;
+  savedAt: number;
+  query: string;
+  nodes: Discussion[];
+  endCursor: string;
+  hasNextPage: boolean;
+}
+
+export function homeFeedStorageKey(query: string): string {
+  return STORAGE_PREFIX + encodeURIComponent(query);
+}
+
+export function readHomeFeedSnapshot(query: string): HomeFeedSnapshot | null {
+  if (!import.meta.client) return null;
+  const key = homeFeedStorageKey(query);
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) return null;
+    const data = JSON.parse(raw) as Partial<HomeFeedSnapshot>;
+    if (data.version !== 1 || typeof data.savedAt !== "number") return null;
+    if (typeof data.query !== "string" || data.query !== query) return null;
+    if (!Array.isArray(data.nodes)) return null;
+    if (typeof data.endCursor !== "string") return null;
+    if (typeof data.hasNextPage !== "boolean") return null;
+    return data as HomeFeedSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+export function writeHomeFeedSnapshot(payload: {
+  query: string;
+  nodes: Discussion[];
+  endCursor: string;
+  hasNextPage: boolean;
+}): void {
+  if (!import.meta.client) return;
+  const key = homeFeedStorageKey(payload.query);
+  const snapshot: HomeFeedSnapshot = {
+    version: 1,
+    savedAt: Date.now(),
+    query: payload.query,
+    nodes: payload.nodes,
+    endCursor: payload.endCursor,
+    hasNextPage: payload.hasNextPage,
+  };
+  try {
+    sessionStorage.setItem(key, JSON.stringify(snapshot));
+  } catch {
+    // QuotaExceededError or private mode — ignore
+  }
+}
+
+export function clearHomeFeedSnapshot(query: string): void {
+  if (!import.meta.client) return;
+  try {
+    sessionStorage.removeItem(homeFeedStorageKey(query));
+  } catch {
+    // ignore
+  }
+}

--- a/app/utils/profile-page-cache.ts
+++ b/app/utils/profile-page-cache.ts
@@ -1,0 +1,77 @@
+import type { Discussion, Profile } from "~/types/entities";
+
+const STORAGE_PREFIX = "ik-profile:v1:";
+
+export interface ProfilePageSnapshot {
+  version: 1;
+  savedAt: number;
+  profileId: string;
+  profile: Profile;
+  articles: Discussion[];
+  articleCursor: string;
+  articleHasNext: boolean;
+}
+
+export function profilePageStorageKey(profileId: string): string {
+  return STORAGE_PREFIX + encodeURIComponent(profileId);
+}
+
+function isProfileRecord(v: unknown): v is Profile {
+  return (
+    !!v &&
+    typeof v === "object" &&
+    typeof (v as Profile).documentId === "string" &&
+    (v as Profile).documentId.length > 0
+  );
+}
+
+export function readProfilePageSnapshot(profileId: string): ProfilePageSnapshot | null {
+  if (!import.meta.client || !profileId) return null;
+  try {
+    const raw = sessionStorage.getItem(profilePageStorageKey(profileId));
+    if (!raw) return null;
+    const data = JSON.parse(raw) as Partial<ProfilePageSnapshot>;
+    if (data.version !== 1 || typeof data.savedAt !== "number") return null;
+    if (typeof data.profileId !== "string" || data.profileId !== profileId) return null;
+    if (!isProfileRecord(data.profile) || data.profile.documentId !== profileId) return null;
+    if (!Array.isArray(data.articles)) return null;
+    if (typeof data.articleCursor !== "string") return null;
+    if (typeof data.articleHasNext !== "boolean") return null;
+    return data as ProfilePageSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+export function writeProfilePageSnapshot(payload: {
+  profileId: string;
+  profile: Profile;
+  articles: Discussion[];
+  articleCursor: string;
+  articleHasNext: boolean;
+}): void {
+  if (!import.meta.client || !payload.profileId) return;
+  const snapshot: ProfilePageSnapshot = {
+    version: 1,
+    savedAt: Date.now(),
+    profileId: payload.profileId,
+    profile: payload.profile,
+    articles: payload.articles,
+    articleCursor: payload.articleCursor,
+    articleHasNext: payload.articleHasNext,
+  };
+  try {
+    sessionStorage.setItem(profilePageStorageKey(payload.profileId), JSON.stringify(snapshot));
+  } catch {
+    // QuotaExceededError or private mode — ignore
+  }
+}
+
+export function clearProfilePageSnapshot(profileId: string): void {
+  if (!import.meta.client || !profileId) return;
+  try {
+    sessionStorage.removeItem(profilePageStorageKey(profileId));
+  } catch {
+    // ignore
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,6 +20,8 @@ export default defineNuxtConfig({
     public: {
       apiBaseUrl: "",
       appName: "绳网",
+      /** Dev/preview: set `NUXT_PUBLIC_ENABLE_SERVICE_WORKER=true` to register `/sw.js`. Production always registers via the client plugin. */
+      enableServiceWorker: process.env.NUXT_PUBLIC_ENABLE_SERVICE_WORKER === "true",
     },
   },
   app: {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,86 @@
+/**
+ * InterKnot media cache — cache-first for images/fonts/static media only.
+ * All /api/* requests bypass Cache Storage (network-only) so discussion data always comes from the server.
+ */
+const CACHE_NAME = "ik-media-v1";
+const CACHE_PREFIX = "ik-media-";
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k.startsWith(CACHE_PREFIX) && k !== CACHE_NAME).map((k) => caches.delete(k)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+/**
+ * @param {string} url
+ */
+function isApiRequest(url) {
+  try {
+    return new URL(url).pathname.startsWith("/api/");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {Request} request
+ */
+function isMediaResource(request) {
+  if (request.method !== "GET") return false;
+  const dest = request.destination;
+  if (dest === "image" || dest === "font") return true;
+  try {
+    const pathname = new URL(request.url).pathname;
+    if (pathname.includes("/uploads/")) return true;
+    return /\.(webp|avif|jpg|jpeg|png|gif|svg|woff2?|ico)$/i.test(pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {Request} request
+ */
+async function cacheFirstMedia(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const hit = await cache.match(request);
+  if (hit) return hit;
+
+  const response = await fetch(request);
+  if (response && (response.ok || response.type === "opaque")) {
+    try {
+      await cache.put(request, response.clone());
+    } catch {
+      // Quota or unsupported response — still return live response
+    }
+  }
+  return response;
+}
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  if (request.method !== "GET") return;
+
+  const url = request.url;
+  if (isApiRequest(url)) {
+    event.respondWith(fetch(request));
+    return;
+  }
+
+  if (isMediaResource(request)) {
+    event.respondWith(
+      cacheFirstMedia(request).catch(() => fetch(request)),
+    );
+  }
+});


### PR DESCRIPTION
feat(service-worker): 添加具有选择性媒体缓存功能的 Service Worker

添加 Service Worker 注册插件，默认仅在生产环境启用，并支持在开发环境中通过配置开启。对媒体资源（图像、字体、静态文件）实现缓存优先策略，同时绕过所有 /api/* 请求的缓存以确保数据实时性。

该 Service Worker：
• 使用缓存优先策略缓存媒体资源
• 绕过 API 请求的缓存（仅网络）
• 在激活期间清理旧版本的缓存
• 仅在生产环境或通过 NUXT_PUBLIC_ENABLE_SERVICE_WORKER 环境变量明确启用时进行注册

---

feat(home-feed): 添加基于 sessionStorage 的持久化缓存

实现首页 Feed 流数据的 sessionStorage 客户端缓存，以提升感官性能并在页面导航时保留滚动位置和状态。增加了用于读取/写入快照的工具函数，并修改了获取数据的逻辑，以支持“静默模式”——该模式可以在不触发进度条和置顶行为的情况下更新缓存。

---

feat(profile): 实现具有过期响应保护的 sessionStorage 缓存

为个人资料页面添加基于 sessionStorage 的客户端缓存，以提升性能并跨导航保留滚动位置和状态。通过实现轮次序列追踪，防止过期响应覆盖最新的 UI 或缓存数据，并包含用于在导航时恢复缓存内容的注水逻辑。引入专门的工具模块用于个人资料页面快照管理，支持版本化存储格式及校验。